### PR TITLE
Support for loading in FP8 mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,11 @@ python app.py --mode 2 --zh
 python app.py  --mode 3
 ```
 
+```
+# For 20~32GB VRAM GPU, FP8 quantization. Slower than NF4 or INT8, but useful if bitsandbytes is not supported, e.g. some AMD GPUs
+python app.py --mode 4
+```
+
 ## 🔥 Train & Eval
 
 ### Train

--- a/app.py
+++ b/app.py
@@ -129,6 +129,16 @@ elif args.mode == 3: # INT8
         device_map=device_map,
         offload_folder="offload",
     ).eval()
+elif args.mode == 4: # FP8
+    model = load_checkpoint_and_dispatch(
+        model,
+        checkpoint=os.path.join(model_path, "ema.safetensors"),
+        device_map=device_map,
+        offload_buffers=True,
+        offload_folder="offload",
+        dtype=torch.float8_e4m3fn,
+        force_hooks=True,
+    ).eval()
 else:
     raise NotImplementedError
 

--- a/modeling/bagel/bagel.py
+++ b/modeling/bagel/bagel.py
@@ -388,6 +388,8 @@ class Bagel(PreTrainedModel):
         )
         packed_vit_token_embed = self.connector(packed_vit_token_embed)
         pos_emb = self.vit_pos_embed(packed_vit_position_ids)
+        if pos_emb.dtype == torch.float8_e4m3fn:
+            pos_emb = pos_emb.to(packed_vit_token_embed.dtype)
         packed_vit_token_embed = packed_vit_token_embed + pos_emb
         if packed_vit_token_embed.dtype != packed_sequence.dtype:
             packed_vit_token_embed = packed_vit_token_embed.to(packed_sequence.dtype)
@@ -519,6 +521,8 @@ class Bagel(PreTrainedModel):
         packed_latent = torch.cat(packed_latent, dim=0)
         packed_pos_embed = self.latent_pos_embed(packed_vae_position_ids)
         packed_timestep_embeds = self.time_embedder(packed_timesteps)
+        if packed_pos_embed.dtype != packed_timestep_embeds.dtype:
+            packed_pos_embed = packed_pos_embed.to(packed_timestep_embeds.dtype)
         packed_latent = self.vae2llm(packed_latent) + packed_timestep_embeds + packed_pos_embed
         if packed_latent.dtype != packed_sequence.dtype:
             packed_latent = packed_latent.to(packed_sequence.dtype)
@@ -767,6 +771,8 @@ class Bagel(PreTrainedModel):
         assert timestep.unique().shape[0] == 1
         packed_pos_embed = self.latent_pos_embed(packed_vae_position_ids)
         packed_timestep_embeds = self.time_embedder(timestep)
+        if packed_pos_embed.dtype == torch.float8_e4m3fn:
+            packed_pos_embed = packed_pos_embed.to(packed_timestep_embeds.dtype)
         x_t = self.vae2llm(x_t) + packed_timestep_embeds + packed_pos_embed
         if x_t.dtype != packed_sequence.dtype:
             x_t = x_t.to(packed_sequence.dtype)

--- a/modeling/bagel/siglip_navit.py
+++ b/modeling/bagel/siglip_navit.py
@@ -189,7 +189,10 @@ class SiglipVisionEmbeddings(nn.Module):
 
         patch_embeds = self.patch_embedding(packed_pixel_values)
         if not self.config.rope:
-            embeddings = patch_embeds + self.position_embedding(packed_flattened_position_ids)
+            pos_embeds = self.position_embedding(packed_flattened_position_ids)
+            if pos_embeds.dtype == torch.float8_e4m3fn:
+                pos_embeds = pos_embeds.to(patch_embeds.dtype)
+            embeddings = patch_embeds + pos_embeds
         else:
             embeddings = patch_embeds
         return embeddings


### PR DESCRIPTION
Unfortunately, the 7900XTX and other consumer-grade AMD GPUs don't *really* support bitsandbytes. Or dfloat11. But, FP8 support works fine. With this patch, I can load and run BAGEL on a 7900XTX. Unfortunately, it still takes about 17GB at max, so it's too much for a 16GB card, but it does work, and it's a heck of a lot faster than CPU.

Use --mode 4 to load in FP8 mode. Loads the FP16 model with on-the-fly quantization. Because most math isn't supported in FP8, the weights are changed dynamically as needed, so a few checks are added to perform the upconversion.