### PR TITLE
Add TaylorSeer Support

### DIFF
--- a/inference.ipynb
+++ b/inference.ipynb
@@ -507,6 +507,56 @@
    "metadata": {},
    "outputs": [],
    "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## TaylorSeer Support for Inference Acceleration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Enable TaylorSeer (https://arxiv.org/abs/2503.06923) by setting enable_taylorseer=True in inference_hyper\n",
+    "# This feature is supported for tasks that involve image output, including image generation, image generation with think, editing, and edit with think.\n",
+    "\n",
+    "# Below is an example of image generation with TaylorSeer enabled.\n",
+    "inference_hyper=dict(\n",
+    "    cfg_text_scale=4.0,\n",
+    "    cfg_img_scale=1.0,\n",
+    "    cfg_interval=[0.4, 1.0],\n",
+    "    timestep_shift=3.0,\n",
+    "    num_timesteps=50,\n",
+    "    cfg_renorm_min=0.0,\n",
+    "    cfg_renorm_type=\"global\",\n",
+    "    enable_taylorseer=True,  # Enable TaylorSeer\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prompt = \"A female cosplayer portraying an ethereal fairy or elf, wearing a flowing dress made of delicate fabrics in soft, mystical colors like emerald green and silver. She has pointed ears, a gentle, enchanting expression, and her outfit is adorned with sparkling jewels and intricate patterns. The background is a magical forest with glowing plants, mystical creatures, and a serene atmosphere.\"\n",
+    "\n",
+    "print(prompt)\n",
+    "print('-' * 10)\n",
+    "output_dict = inferencer(text=prompt, **inference_hyper)\n",
+    "display(output_dict['image'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/inferencer.py
+++ b/inferencer.py
@@ -110,7 +110,8 @@ class InterleaveInferencer:
         cfg_renorm_type="global",
         
         num_timesteps=50, 
-        timestep_shift=3.0
+        timestep_shift=3.0,
+        enable_taylorseer=False,
     ):
         # print(cfg_renorm_type)
         past_key_values = gen_context['past_key_values']
@@ -163,6 +164,7 @@ class InterleaveInferencer:
             cfg_img_packed_query_indexes=generation_input_cfg_img['cfg_packed_query_indexes'],
             cfg_img_key_values_lens=generation_input_cfg_img['cfg_key_values_lens'],
             cfg_img_packed_key_value_indexes=generation_input_cfg_img['cfg_packed_key_value_indexes'],
+            enable_taylorseer=enable_taylorseer,
         )
 
         image = self.decode_image(unpacked_latent[0], image_shape)
@@ -220,6 +222,7 @@ class InterleaveInferencer:
         cfg_renorm_min=0.0,
         cfg_renorm_type="global",
         image_shapes=(1024, 1024),
+        enable_taylorseer=False,
     ) -> List[Union[str, Image.Image]]:
 
         output_list = []
@@ -275,6 +278,7 @@ class InterleaveInferencer:
                     num_timesteps=num_timesteps,
                     cfg_renorm_min=cfg_renorm_min,
                     cfg_renorm_type=cfg_renorm_type,
+                    enable_taylorseer=enable_taylorseer,
                 )
 
                 output_list.append(img)

--- a/modeling/cache_utils/taylorseer.py
+++ b/modeling/cache_utils/taylorseer.py
@@ -1,0 +1,153 @@
+"""
+Utility for TaylorSeer
+"""
+# Adapted from https://github.com/Shenyi-Z/TaylorSeer/blob/main/TaylorSeers-xDiT/taylorseer_flux/taylorseer_utils/__init__.py
+
+from typing import Dict 
+import torch
+import math
+
+
+def derivative_approximation(cache_dic: Dict, current: Dict, feature: torch.Tensor):
+    """
+    Compute derivative approximation.
+    
+    :param cache_dic: Cache dictionary
+    :param current: Information of the current step
+    """
+    difference_distance = current['activated_steps'][-1] - current['activated_steps'][-2]
+
+    updated_taylor_factors = {}
+    updated_taylor_factors[0] = feature
+
+    for i in range(cache_dic['max_order']):
+        if (cache_dic['cache'][-1][current['stream']][current['layer']][current['module']].get(i, None) is not None) and (current['step'] > cache_dic['first_enhance'] - 2):
+            updated_taylor_factors[i + 1] = (updated_taylor_factors[i] - cache_dic['cache'][-1][current['stream']][current['layer']][current['module']][i]) / difference_distance
+        else:
+            break
+
+    cache_dic['cache'][-1][current['stream']][current['layer']][current['module']] = updated_taylor_factors
+
+def taylor_formula(cache_dic: Dict, current: Dict) -> torch.Tensor: 
+    """
+    Compute Taylor expansion error.
+    
+    :param cache_dic: Cache dictionary
+    :param current: Information of the current step
+    """
+    x = current['step'] - current['activated_steps'][-1]
+    #x = current['t'] - current['activated_times'][-1]
+    output = 0
+
+    for i in range(len(cache_dic['cache'][-1][current['stream']][current['layer']][current['module']])):
+        output += (1 / math.factorial(i)) * cache_dic['cache'][-1][current['stream']][current['layer']][current['module']][i] * (x ** i)
+
+    return output
+
+def taylor_cache_init(cache_dic: Dict, current: Dict):
+    """
+    Initialize Taylor cache and allocate storage for different-order derivatives in the Taylor cache.
+    
+    :param cache_dic: Cache dictionary
+    :param current: Information of the current step
+    """
+    if (current['step'] == 0) and (cache_dic['taylor_cache']):
+        cache_dic['cache'][-1][current['stream']][current['layer']][current['module']] = {}
+
+
+# Copied from https://github.com/Shenyi-Z/TaylorSeer/blob/main/TaylorSeers-xDiT/taylorseer_flux/cache_functions/force_scheduler.py
+
+def force_scheduler(cache_dic, current):
+    if cache_dic['fresh_ratio'] == 0:
+        # FORA
+        linear_step_weight = 0.0
+    else: 
+        # TokenCache
+        linear_step_weight = 0.0
+    step_factor = torch.tensor(1 - linear_step_weight + 2 * linear_step_weight * current['step'] / current['num_steps'])
+    threshold = torch.round(cache_dic['fresh_threshold'] / step_factor)
+
+    # no force constrain for sensitive steps, cause the performance is good enough.
+    # you may have a try.
+
+    cache_dic['cal_threshold'] = threshold
+    #return threshold
+
+
+# Copied from https://github.com/Shenyi-Z/TaylorSeer/blob/main/TaylorSeers-xDiT/taylorseer_flux/cache_functions/cal_type.py
+
+def cal_type(cache_dic, current):
+    '''
+    Determine calculation type for this step
+    '''
+    if (cache_dic['fresh_ratio'] == 0.0) and (not cache_dic['taylor_cache']):
+        # FORA:Uniform
+        first_step = (current['step'] == 0)
+    else:
+        # ToCa: First enhanced
+        first_step = (current['step'] < cache_dic['first_enhance'])
+
+    if not first_step:
+        fresh_interval = cache_dic['cal_threshold']
+    else:
+        fresh_interval = cache_dic['fresh_threshold']
+
+    if (first_step) or (cache_dic['cache_counter'] == fresh_interval - 1 ):
+        current['type'] = 'full'
+        cache_dic['cache_counter'] = 0
+        current['activated_steps'].append(current['step'])
+        force_scheduler(cache_dic, current)
+
+    elif (cache_dic['taylor_cache']):
+        cache_dic['cache_counter'] += 1
+        current['type'] = 'Taylor'
+
+    elif (cache_dic['cache_counter'] % 2 == 1): # 0: ToCa-Aggresive-ToCa, 1: Aggresive-ToCa-Aggresive
+        cache_dic['cache_counter'] += 1
+        current['type'] = 'ToCa'
+    # 'cache_noise' 'ToCa' 'FORA'
+    elif cache_dic['Delta-DiT']:
+        cache_dic['cache_counter'] += 1
+        current['type'] = 'Delta-Cache'
+    else:
+        cache_dic['cache_counter'] += 1
+        current['type'] = 'ToCa'
+
+
+# Modified from https://github.com/Shenyi-Z/TaylorSeer/blob/main/TaylorSeers-xDiT/taylorseer_flux/cache_functions/cache_init.py
+
+def cache_init(self, num_steps: int):
+    '''
+    Initialization for cache.
+    '''
+    cache_dic = {}
+    cache = {}
+    cache_index = {}
+    cache[-1]={}
+    cache_index[-1]={}
+    cache_index['layer_index']={}
+    cache[-1]['layers_stream']={}
+    cache_dic['cache_counter'] = 0
+
+    for j in range(len(self.language_model.model.layers)):
+        cache[-1]['layers_stream'][j] = {}
+        cache_index[-1][j] = {}
+
+    cache_dic['Delta-DiT'] = False
+    cache_dic['cache_type'] = 'random'
+    cache_dic['cache_index'] = cache_index
+    cache_dic['cache'] = cache
+    cache_dic['fresh_ratio_schedule'] = 'ToCa' 
+    cache_dic['fresh_ratio'] = 0.0
+    cache_dic['fresh_threshold'] = 3
+    cache_dic['soft_fresh_weight'] = 0.0
+    cache_dic['taylor_cache'] = True
+    cache_dic['max_order'] = 6
+    cache_dic['first_enhance'] = 5
+
+    current = {}
+    current['activated_steps'] = [0]
+    current['step'] = 0
+    current['num_steps'] = num_steps
+
+    return cache_dic, current


### PR DESCRIPTION
This PR adds the support of TaylorSeer (https://arxiv.org/abs/2503.06923) for accelerating image-output related inference tasks.

**How to enable TaylorSeer**
Simply setting `enable_taylorseer=True` in `inference_hyper` when calling `inferencer`. The default value is `False`. I have added a cell on the bottom of `inference.ipynb` to demonstrate a use case with TaylorSeer enabled.

**Supported Tasks**
TaylorSeer is a diffusion cache approach. Therefore it works for image-output related tasks, including image generation (with think) and editing (with think). It has been tested for all these tasks.

**Performance**
TaylorSeer on Bagel achieves ~2.2x speedup, without notable quality degradation. Here I provide a benchmark case on image generation, using the prompt and setup described in `inference.ipynb`.

[Original Generated Image] [Time: 36s, on 1 A100 GPU]
<img width="1024" height="1024" alt="ori_t2i" src="https://github.com/user-attachments/assets/1e5eaaff-36ae-4b63-a9a0-70449ee20421" />

[TaylorSeer Generated Image] [Time: 16s, on 1 A100 GPU]
<img width="1024" height="1024" alt="taylorseer_t2i" src="https://github.com/user-attachments/assets/d081af8b-994b-44e3-a3e4-85b2da964109" />

It is observed that TaylorSeer accelerates the generation from 36s to 16s, tested on 1 A100 GPU. The image quality remains unaffected.

Please let me know if this contributes to a nice addition!

Best,
Jiaqi Han