### PR TITLE
integrate support for mfu tracking, including hardware-specific peak TFLOPs detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ eval_results
 tests
 .DS_Store
 gradio.sh
+data_example


### PR DESCRIPTION
# Add MFU Tracking and Hardware-Specific Peak TFLOPs Detection

This PR integrates Model FLOPs Utilization (MFU) tracking into the training pipeline, enabling real-time monitoring of GPU compute efficiency.

The implementation includes:

1. Automatic hardware detection for various GPU models (MI300X, H100/H800/H200, A100/A800, L40/L20, H20, Ascend 910B, etc.).
2. FLOPs calculation for the Qwen2/2.5/3 architecture, and training metrics including tokens/sec, actual TFLOPs, and MFU percentage.
3. Accept manual specification via the `--peak_device_tflops` argument. 

Also fixed some small issues:

1. Additional improvements include gradient accumulation (`--gradient_accumulation_steps`), better OOM error handling.
2. Checkpoint saving with proper CUDA synchronization and memory management, model parameter counting, and automatic final checkpoint save at training completion.