### PR TITLE
Add tensor-parallel inference for BAGEL

### DIFF
--- a/infer_tp.py
+++ b/infer_tp.py
@@ -1,0 +1,196 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tensor-parallel inference entrypoint for BAGEL.
+
+Launch with torchrun, one process per GPU:
+
+    torchrun --nproc_per_node=4 infer_tp.py \
+        --model_path models/BAGEL-7B-MoT \
+        --prompt "a teapot shaped like a cat, studio photo" \
+        --output out.png
+
+All ranks run the same code (SPMD). The 28 LLM decoder layers are tensor-
+sharded across the GPUs (see modeling/tp_utils.py); ViT / VAE / embeddings
+are replicated. The Bagel model is constructed with TP-local parameter shapes
+and the checkpoint is sliced per-rank on load, so no rank ever holds the full
+weights. The reconstructed activations are identical on every rank, so it is
+safe for rank 0 to be the one that saves the output image.
+
+Falls back to a normal single-GPU run when launched without torchrun
+(WORLD_SIZE unset / == 1).
+"""
+
+import argparse
+import contextlib
+import os
+import random
+import time
+
+import numpy as np
+import torch
+
+from accelerate import init_empty_weights  # noqa: F401  (kept for parity / debugging)
+
+from data.data_utils import add_special_tokens
+from data.transforms import ImageTransform
+from inferencer import InterleaveInferencer
+from modeling.autoencoder import load_ae
+from modeling.bagel import (
+    BagelConfig, Bagel, Qwen2Config, Qwen2ForCausalLM,
+    SiglipVisionConfig, SiglipVisionModel,
+)
+from modeling.tp_utils import (
+    init_tensor_parallel, get_tp_rank, get_tp_world_size, load_sharded_checkpoint,
+    tp_barrier,
+)
+from modeling.qwen2 import Qwen2Tokenizer
+
+
+def set_seed(seed):
+    """Seed every rank identically so replicated (noise / sampling) computations match."""
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed(seed)
+        torch.cuda.manual_seed_all(seed)
+
+
+def build_model(model_path, device, dtype):
+    """Construct the Bagel model with TP-local shapes directly on `device`.
+
+    We build on the real device (not meta) so that non-checkpoint buffers such as
+    the rotary embedding inv_freq are materialised correctly. Parallel linears are
+    already local-sized, so per-rank memory is ~1/world_size of the LLM weights.
+    """
+    llm_config = Qwen2Config.from_json_file(os.path.join(model_path, "llm_config.json"))
+    llm_config.qk_norm = True
+    llm_config.tie_word_embeddings = False
+    llm_config.layer_module = "Qwen2MoTDecoderLayer"
+
+    vit_config = SiglipVisionConfig.from_json_file(os.path.join(model_path, "vit_config.json"))
+    vit_config.rope = False
+    vit_config.num_hidden_layers -= 1
+
+    vae_model, vae_config = load_ae(local_path=os.path.join(model_path, "ae.safetensors"))
+
+    config = BagelConfig(
+        visual_gen=True,
+        visual_und=True,
+        llm_config=llm_config,
+        vit_config=vit_config,
+        vae_config=vae_config,
+        vit_max_num_patch_per_side=70,
+        connector_act='gelu_pytorch_tanh',
+        latent_patch_size=2,
+        max_latent_size=64,
+    )
+
+    prev_default_dtype = torch.get_default_dtype()
+    torch.set_default_dtype(dtype)
+    try:
+        with torch.device(device):
+            language_model = Qwen2ForCausalLM(llm_config)
+            vit_model = SiglipVisionModel(vit_config)
+            model = Bagel(language_model, vit_model, config)
+            model.vit_model.vision_model.embeddings.convert_conv2d_to_linear(vit_config, meta=False)
+    finally:
+        torch.set_default_dtype(prev_default_dtype)
+
+    return model, vae_model, config
+
+
+def load_inferencer(model_path, device, dtype=torch.bfloat16):
+    """Build the TP-sharded Bagel model on `device`, load weights, and wrap it in
+    an InterleaveInferencer. Reused by both the single-prompt entrypoint and the
+    dataset edit driver. `init_tensor_parallel()` must have been called first.
+    """
+    model, vae_model, config = build_model(model_path, device, dtype)
+
+    # Slice + load the checkpoint into this rank's local shards.
+    load_sharded_checkpoint(model, os.path.join(model_path, "ema.safetensors"))
+    model = model.eval()
+
+    # Keep the VAE in its loaded precision; the inferencer autocasts to bf16 for compute.
+    vae_model = vae_model.to(device).eval()
+
+    tokenizer = Qwen2Tokenizer.from_pretrained(model_path)
+    tokenizer, new_token_ids, _ = add_special_tokens(tokenizer)
+
+    vae_transform = ImageTransform(1024, 512, 16)
+    vit_transform = ImageTransform(980, 224, 14)
+
+    inferencer = InterleaveInferencer(
+        model=model,
+        vae_model=vae_model,
+        tokenizer=tokenizer,
+        vae_transform=vae_transform,
+        vit_transform=vit_transform,
+        new_token_ids=new_token_ids,
+    )
+    return inferencer
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model_path", type=str, default="models/BAGEL-7B-MoT")
+    parser.add_argument("--prompt", type=str, default="a teapot shaped like a cat, studio photo")
+    parser.add_argument("--output", type=str, default="out_tp.png")
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--num_timesteps", type=int, default=50)
+    parser.add_argument("--cfg_text_scale", type=float, default=4.0)
+    parser.add_argument("--image_size", type=int, default=1024)
+    parser.add_argument("--benchmark", action="store_true", help="time the generation and report on rank 0")
+    args = parser.parse_args()
+
+    local_rank = init_tensor_parallel()
+    rank = get_tp_rank()
+    world_size = get_tp_world_size()
+    device = torch.device(f"cuda:{local_rank}")
+    dtype = torch.bfloat16
+
+    def log(msg):
+        if rank == 0:
+            print(msg, flush=True)
+
+    log(f"[TP] world_size={world_size}, building model on each rank ...")
+
+    inferencer = load_inferencer(args.model_path, device, dtype)
+
+    # Identical seed on every rank -> identical replicated noise / sampling.
+    set_seed(args.seed)
+    tp_barrier()
+
+    log(f"[TP] generating: {args.prompt!r}")
+    if args.benchmark:
+        torch.cuda.synchronize()
+        tp_barrier()
+        t0 = time.time()
+
+    output = inferencer(
+        text=args.prompt,
+        think=False,
+        image_shapes=(args.image_size, args.image_size),
+        num_timesteps=args.num_timesteps,
+        cfg_text_scale=args.cfg_text_scale,
+        understanding_output=False,
+    )
+
+    if args.benchmark:
+        torch.cuda.synchronize()
+        tp_barrier()
+        if rank == 0:
+            print(f"[TP] generation took {time.time() - t0:.2f}s "
+                  f"({args.num_timesteps} steps, world_size={world_size})", flush=True)
+
+    if rank == 0:
+        image = output["image"]
+        image.save(args.output)
+        print(f"[TP] saved -> {args.output}", flush=True)
+
+    tp_barrier()
+
+
+if __name__ == "__main__":
+    main()

--- a/infer_tp_edit.py
+++ b/infer_tp_edit.py
@@ -1,0 +1,167 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tensor-parallel edit-dataset inference for BAGEL.
+
+Runs an image-editing dataset through the tensor-parallel model. Unlike the
+data-parallel eval scripts (eval/gen/gen_images_mp_imgedit.py), here ALL ranks
+collaborate on ONE edit at a time (SPMD lockstep), so each edit is faster but the
+dataset is walked sequentially.
+
+Lockstep contract (important): every rank builds the SAME dataset, iterates it in
+the SAME order, and runs every sample together so the per-layer all-reduces stay
+in sync. Do NOT use a DistributedSampler / shard the dataset -- that desyncs the
+collectives and will hang. Only rank 0 writes outputs.
+
+Launch (one process per GPU):
+
+    torchrun --nproc_per_node=4 infer_tp_edit.py \
+        --model_path models/BAGEL-7B-MoT \
+        --output_dir edits_out \
+        --cfg_img_scale 2.0 --cfg_text_scale 4.0
+
+Plug your dataset into `build_dataset()` below. It is assumed to be a map-style
+dataset (supports len() and dataset[i]) whose items yield (text, image), where
+`text` is the edit instruction and `image` is a PIL.Image or a path to one.
+"""
+
+import argparse
+import json
+import os
+import time
+
+import torch
+from PIL import Image
+
+from data.data_utils import pil_img2rgb
+from infer_tp import load_inferencer, set_seed
+from modeling.tp_utils import (
+    init_tensor_parallel, get_tp_rank, get_tp_world_size, tp_barrier,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Plug your dataset in here.
+# --------------------------------------------------------------------------- #
+def build_dataset(args):
+    """Return a map-style dataset where dataset[i] -> (text, image).
+
+    Replace the body with the construction of YOUR dataset class. It must be
+    built identically on every rank (same args, same order) -- no random shuffle
+    unless seeded identically. Example:
+
+        from your_module import EditDataset
+        return EditDataset(args.data_root, split="test")
+    """
+    raise NotImplementedError(
+        "Edit build_dataset() to construct and return your edit dataset "
+        "(map-style, dataset[i] -> (text, image))."
+    )
+
+
+def normalize_item(item):
+    """Coerce a dataset item into (instruction_text, PIL.Image).
+
+    Accepts (text, image) or (image, text); `image` may be a PIL.Image or a path.
+    """
+    a, b = item
+    # Figure out which element is the image.
+    if isinstance(a, Image.Image) or (isinstance(a, str) and os.path.exists(a)):
+        image, text = a, b
+    else:
+        text, image = a, b
+    if isinstance(image, str):
+        image = Image.open(image)
+    image = pil_img2rgb(image)
+    return text, image
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model_path", type=str, default="models/BAGEL-7B-MoT")
+    parser.add_argument("--output_dir", type=str, default="edits_out")
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--limit", type=int, default=-1, help="only process the first N items (debug)")
+    parser.add_argument("--resume", action="store_true", help="skip items whose output already exists")
+    parser.add_argument("--think", action="store_true", help="enable chain-of-thought editing")
+    # Edit CFG defaults mirror eval/gen/gen_images_mp_imgedit.py.
+    parser.add_argument("--num_timesteps", type=int, default=50)
+    parser.add_argument("--cfg_text_scale", type=float, default=4.0)
+    parser.add_argument("--cfg_img_scale", type=float, default=2.0)
+    parser.add_argument("--cfg_renorm_min", type=float, default=0.0)
+    parser.add_argument("--cfg_renorm_type", type=str, default="text_channel")
+    parser.add_argument("--timestep_shift", type=float, default=3.0)
+    args = parser.parse_args()
+
+    local_rank = init_tensor_parallel()
+    rank = get_tp_rank()
+    world_size = get_tp_world_size()
+    device = torch.device(f"cuda:{local_rank}")
+
+    def log(msg):
+        if rank == 0:
+            print(msg, flush=True)
+
+    log(f"[TP-edit] world_size={world_size}, building model on each rank ...")
+    inferencer = load_inferencer(args.model_path, device, torch.bfloat16)
+
+    dataset = build_dataset(args)
+    n = len(dataset)
+    if args.limit >= 0:
+        n = min(n, args.limit)
+    log(f"[TP-edit] dataset has {len(dataset)} items, processing {n}")
+
+    if rank == 0:
+        os.makedirs(args.output_dir, exist_ok=True)
+        manifest = open(os.path.join(args.output_dir, "manifest.jsonl"), "a")
+
+    tp_barrier()
+    t0 = time.time()
+    done = 0
+
+    for idx in range(n):
+        out_path = os.path.join(args.output_dir, f"{idx:06d}.png")
+        # Deterministic skip: identical on every rank -> stays in lockstep.
+        if args.resume and os.path.exists(out_path):
+            continue
+
+        # Re-seed per sample BEFORE the fetch so any randomness in __getitem__
+        # (augmentation, etc.) AND the diffusion noise are reproducible and
+        # identical across ranks. Divergent inputs across ranks would desync the
+        # tensor-parallel all-reduces.
+        set_seed(args.seed + idx)
+        text, image = normalize_item(dataset[idx])
+
+        output = inferencer(
+            image=image,
+            text=text,
+            think=args.think,
+            num_timesteps=args.num_timesteps,
+            cfg_text_scale=args.cfg_text_scale,
+            cfg_img_scale=args.cfg_img_scale,
+            cfg_renorm_min=args.cfg_renorm_min,
+            cfg_renorm_type=args.cfg_renorm_type,
+            timestep_shift=args.timestep_shift,
+            understanding_output=False,
+        )
+
+        if rank == 0:
+            output["image"].save(out_path)
+            record = {"index": idx, "prompt": text, "output": os.path.basename(out_path)}
+            if output.get("text"):
+                record["think"] = output["text"]
+            manifest.write(json.dumps(record, ensure_ascii=False) + "\n")
+            manifest.flush()
+
+        done += 1
+        if done % 10 == 0:
+            log(f"[TP-edit] {done}/{n} done ({(time.time() - t0) / done:.2f}s/item)")
+
+    tp_barrier()
+    if rank == 0:
+        manifest.close()
+        print(f"[TP-edit] finished {done} items in {time.time() - t0:.1f}s -> {args.output_dir}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/modeling/bagel/qwen2_navit.py
+++ b/modeling/bagel/qwen2_navit.py
@@ -32,6 +32,7 @@ from modeling.qwen2.modeling_qwen2 import (
 )
 
 from modeling.qwen2.configuration_qwen2 import Qwen2Config as _Qwen2Config
+from modeling.tp_utils import ColumnParallelLinear, RowParallelLinear
 from modeling.cache_utils.taylorseer import (
     cal_type, taylor_cache_init, derivative_approximation, taylor_formula,
 )
@@ -305,7 +306,7 @@ class PackedAttention(Qwen2Attention):
             end_index = packed_attn_output.shape[2] - pad_size
             packed_attn_output = packed_attn_output[0, :, :end_index, :]
 
-        packed_attn_output = packed_attn_output.transpose(0, 1).reshape(-1, self.hidden_size)
+        packed_attn_output = packed_attn_output.transpose(0, 1).reshape(-1, self.attn_inner_dim)
         packed_attn_output = self.o_proj(packed_attn_output)
 
         return packed_attn_output
@@ -368,7 +369,7 @@ class PackedAttention(Qwen2Attention):
             max_seqlen_k=max(key_values_lens).item(),
             causal=is_causal,
         )
-        packed_attn_output = packed_attn_output.reshape(-1, self.hidden_size)
+        packed_attn_output = packed_attn_output.reshape(-1, self.attn_inner_dim)
         packed_attn_output = self.o_proj(packed_attn_output)
 
         if update_past_key_values:
@@ -392,10 +393,15 @@ class PackedAttentionMoT(Qwen2Attention):
             self.q_norm_moe_gen = nn.Identity()
             self.k_norm_moe_gen = nn.Identity()
 
-        self.q_proj_moe_gen = nn.Linear(self.hidden_size, self.num_heads * self.head_dim, bias=True)
-        self.k_proj_moe_gen = nn.Linear(self.hidden_size, self.num_key_value_heads * self.head_dim, bias=True)
-        self.v_proj_moe_gen = nn.Linear(self.hidden_size, self.num_key_value_heads * self.head_dim, bias=True)
-        self.o_proj_moe_gen = nn.Linear(self.num_heads * self.head_dim, self.hidden_size, bias=False)
+        # Mirror the sharding of the base und projections: q/k/v column-parallel,
+        # o row-parallel. self.num_heads / self.num_key_value_heads are already the
+        # per-rank (local) counts set by Qwen2Attention.__init__.
+        global_num_heads = config.num_attention_heads
+        global_num_kv_heads = config.num_key_value_heads
+        self.q_proj_moe_gen = ColumnParallelLinear(self.hidden_size, global_num_heads * self.head_dim, bias=True)
+        self.k_proj_moe_gen = ColumnParallelLinear(self.hidden_size, global_num_kv_heads * self.head_dim, bias=True)
+        self.v_proj_moe_gen = ColumnParallelLinear(self.hidden_size, global_num_kv_heads * self.head_dim, bias=True)
+        self.o_proj_moe_gen = RowParallelLinear(global_num_heads * self.head_dim, self.hidden_size, bias=False)
 
     def forward(self, *args, **kwargs):
         if self.training:
@@ -586,7 +592,7 @@ class PackedAttentionMoT(Qwen2Attention):
             max_seqlen_k=max(key_values_lens).item(),
             causal=is_causal,
         )
-        packed_attn_output = packed_attn_output.reshape(-1, self.hidden_size)
+        packed_attn_output = packed_attn_output.reshape(-1, self.attn_inner_dim)
         if mode == 'und':
             packed_attn_output = self.o_proj(packed_attn_output)
         elif mode == 'gen':

--- a/modeling/qwen2/modeling_qwen2.py
+++ b/modeling/qwen2/modeling_qwen2.py
@@ -28,6 +28,7 @@ from transformers.utils import (
     replace_return_docstrings,
 )
 from .configuration_qwen2 import Qwen2Config
+from ..tp_utils import ColumnParallelLinear, RowParallelLinear, get_tp_world_size
 
 
 if is_flash_attn_2_available():
@@ -192,9 +193,9 @@ class Qwen2MLP(nn.Module):
         super().__init__()
         self.hidden_size = config.hidden_size
         self.intermediate_size = config.intermediate_size
-        self.gate_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
-        self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
-        self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
+        self.gate_proj = ColumnParallelLinear(self.hidden_size, self.intermediate_size, bias=False)
+        self.up_proj = ColumnParallelLinear(self.hidden_size, self.intermediate_size, bias=False)
+        self.down_proj = RowParallelLinear(self.intermediate_size, self.hidden_size, bias=False)
         self.act_fn = ACT2FN[config.hidden_act]
 
     def forward(self, hidden_state):
@@ -232,24 +233,38 @@ class Qwen2Attention(nn.Module):
             )
 
         self.hidden_size = config.hidden_size
-        self.num_heads = config.num_attention_heads
-        self.head_dim = self.hidden_size // self.num_heads
-        self.num_key_value_heads = config.num_key_value_heads
+        # head_dim is derived from the *global* head count; it never changes
+        # under tensor parallelism (we shard whole heads across ranks).
+        self.head_dim = self.hidden_size // config.num_attention_heads
+        if (self.head_dim * config.num_attention_heads) != self.hidden_size:
+            raise ValueError(
+                f"hidden_size must be divisible by num_heads (got `hidden_size`: {self.hidden_size}"
+                f" and `num_heads`: {config.num_attention_heads})."
+            )
+
+        tp_world_size = get_tp_world_size()
+        if config.num_attention_heads % tp_world_size != 0 or config.num_key_value_heads % tp_world_size != 0:
+            raise ValueError(
+                f"num_attention_heads ({config.num_attention_heads}) and num_key_value_heads "
+                f"({config.num_key_value_heads}) must both be divisible by the TP world size ({tp_world_size})."
+            )
+        # Local (this-rank) head counts. Equal to the global counts when TP is off.
+        self.num_heads = config.num_attention_heads // tp_world_size
+        self.num_key_value_heads = config.num_key_value_heads // tp_world_size
         self.num_key_value_groups = self.num_heads // self.num_key_value_heads
+        # Local width of the attention inner dimension (q/o feature size on this rank).
+        self.attn_inner_dim = self.num_heads * self.head_dim
+
         self.max_position_embeddings = config.max_position_embeddings
         self.rope_theta = config.rope_theta
         self.is_causal = config.is_causal
         self.attention_dropout = config.attention_dropout
 
-        if (self.head_dim * self.num_heads) != self.hidden_size:
-            raise ValueError(
-                f"hidden_size must be divisible by num_heads (got `hidden_size`: {self.hidden_size}"
-                f" and `num_heads`: {self.num_heads})."
-            )
-        self.q_proj = nn.Linear(self.hidden_size, self.num_heads * self.head_dim, bias=True)
-        self.k_proj = nn.Linear(self.hidden_size, self.num_key_value_heads * self.head_dim, bias=True)
-        self.v_proj = nn.Linear(self.hidden_size, self.num_key_value_heads * self.head_dim, bias=True)
-        self.o_proj = nn.Linear(self.num_heads * self.head_dim, self.hidden_size, bias=False)
+        # q/k/v are column-parallel (split on heads); o is row-parallel (all-reduce).
+        self.q_proj = ColumnParallelLinear(self.hidden_size, config.num_attention_heads * self.head_dim, bias=True)
+        self.k_proj = ColumnParallelLinear(self.hidden_size, config.num_key_value_heads * self.head_dim, bias=True)
+        self.v_proj = ColumnParallelLinear(self.hidden_size, config.num_key_value_heads * self.head_dim, bias=True)
+        self.o_proj = RowParallelLinear(config.num_attention_heads * self.head_dim, self.hidden_size, bias=False)
 
     def forward(
         self,

--- a/modeling/tp_utils.py
+++ b/modeling/tp_utils.py
@@ -1,0 +1,222 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tensor-parallel (Megatron-style) primitives for BAGEL inference.
+
+The model is a custom Qwen2 "Mixture-of-Transformers" stack with hand-written
+packed attention + a NaiveCache, so HF / vLLM auto-TP cannot be used. This
+module provides the minimal building blocks to shard the LLM decoder layers
+across `WORLD_SIZE` GPUs and run them SPMD under `torchrun`.
+
+Sharding scheme (per decoder layer):
+  - q/k/v_proj (+ _moe_gen)  : column-parallel (split heads across ranks)
+  - o_proj      (+ _moe_gen) : row-parallel  -> all-reduce
+  - gate/up_proj(+ _moe_gen) : column-parallel
+  - down_proj   (+ _moe_gen) : row-parallel  -> all-reduce
+Everything else (layernorms, RoPE, embeddings, lm_head, ViT, VAE) is replicated.
+
+When WORLD_SIZE == 1 (no torchrun / single GPU) every primitive degrades to a
+plain nn.Linear with no communication, so the single-GPU code path is byte-for-
+byte unchanged.
+"""
+
+import os
+from typing import Optional
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+# --------------------------------------------------------------------------- #
+# Process-group state
+# --------------------------------------------------------------------------- #
+_TP_INITIALIZED = False
+_TP_WORLD_SIZE = 1
+_TP_RANK = 0
+_TP_LOCAL_RANK = 0
+
+
+def init_tensor_parallel() -> int:
+    """Initialise the default NCCL process group from torchrun env vars.
+
+    Returns the local rank (== cuda device index for this process). Safe to call
+    when launched without torchrun: stays single-process (world size 1).
+    """
+    global _TP_INITIALIZED, _TP_WORLD_SIZE, _TP_RANK, _TP_LOCAL_RANK
+
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    if world_size <= 1:
+        _TP_INITIALIZED = True
+        return 0
+
+    _TP_RANK = int(os.environ.get("RANK", "0"))
+    _TP_LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+    _TP_WORLD_SIZE = world_size
+
+    torch.cuda.set_device(_TP_LOCAL_RANK)
+    if not dist.is_initialized():
+        dist.init_process_group(backend="nccl")
+    _TP_INITIALIZED = True
+    return _TP_LOCAL_RANK
+
+
+def get_tp_world_size() -> int:
+    return _TP_WORLD_SIZE
+
+
+def get_tp_rank() -> int:
+    return _TP_RANK
+
+
+def get_tp_local_rank() -> int:
+    return _TP_LOCAL_RANK
+
+
+def is_tp_enabled() -> bool:
+    return _TP_WORLD_SIZE > 1
+
+
+def tp_all_reduce(x: torch.Tensor) -> torch.Tensor:
+    """Sum-reduce a tensor across all TP ranks in place (no-op for world size 1)."""
+    if _TP_WORLD_SIZE > 1:
+        dist.all_reduce(x, op=dist.ReduceOp.SUM)
+    return x
+
+
+def tp_barrier() -> None:
+    if _TP_WORLD_SIZE > 1:
+        dist.barrier()
+
+
+# --------------------------------------------------------------------------- #
+# Parallel linear layers
+# --------------------------------------------------------------------------- #
+class ColumnParallelLinear(nn.Module):
+    """Linear with the output dimension sharded across TP ranks.
+
+    Holds a local weight of shape [out_features // world_size, in_features]. The
+    activation stays sharded on the output dim (we never gather here -- the
+    following RowParallelLinear consumes the sharded activation directly).
+    `out_features` must be divisible by the TP world size.
+    """
+
+    def __init__(self, in_features: int, out_features: int, bias: bool = True):
+        super().__init__()
+        ws = get_tp_world_size()
+        assert out_features % ws == 0, (
+            f"ColumnParallelLinear out_features={out_features} not divisible by TP world size {ws}"
+        )
+        self.in_features = in_features
+        self.out_features = out_features
+        self.out_features_local = out_features // ws
+
+        self.weight = nn.Parameter(torch.empty(self.out_features_local, in_features))
+        self.bias = nn.Parameter(torch.empty(self.out_features_local)) if bias else None
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return F.linear(x, self.weight, self.bias)
+
+
+class RowParallelLinear(nn.Module):
+    """Linear with the input dimension sharded across TP ranks.
+
+    Holds a local weight of shape [out_features, in_features // world_size]. The
+    incoming activation is assumed already sharded on the input dim; each rank
+    computes a partial output and we all-reduce to reconstruct the full result.
+    Bias (if any) is added once, after the all-reduce. `in_features` must be
+    divisible by the TP world size.
+    """
+
+    def __init__(self, in_features: int, out_features: int, bias: bool = False):
+        super().__init__()
+        ws = get_tp_world_size()
+        assert in_features % ws == 0, (
+            f"RowParallelLinear in_features={in_features} not divisible by TP world size {ws}"
+        )
+        self.in_features = in_features
+        self.out_features = out_features
+        self.in_features_local = in_features // ws
+
+        self.weight = nn.Parameter(torch.empty(out_features, self.in_features_local))
+        self.bias = nn.Parameter(torch.empty(out_features)) if bias else None
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        out = F.linear(x, self.weight)
+        out = tp_all_reduce(out)
+        if self.bias is not None:
+            out = out + self.bias
+        return out
+
+
+# --------------------------------------------------------------------------- #
+# Sharded checkpoint loader
+# --------------------------------------------------------------------------- #
+# Projection names sharded on the OUTPUT dim (rows / dim 0).
+_COLUMN_PROJ = (
+    "q_proj", "k_proj", "v_proj",
+    "q_proj_moe_gen", "k_proj_moe_gen", "v_proj_moe_gen",
+    "gate_proj", "up_proj",
+)
+# Projection names sharded on the INPUT dim (cols / dim 1).
+_ROW_PROJ = (
+    "o_proj", "o_proj_moe_gen",
+    "down_proj",
+)
+# Only shard inside the LLM decoder stack; ViT/VAE/connectors stay replicated.
+_LLM_LAYER_PREFIX = "language_model.model.layers."
+
+
+def _shard_kind(name: str) -> Optional[str]:
+    """Return 'col', 'row', or None for a checkpoint parameter name."""
+    if _LLM_LAYER_PREFIX not in name:
+        return None
+    for proj in _COLUMN_PROJ:
+        if f".{proj}." in name:
+            return "col"
+    for proj in _ROW_PROJ:
+        if f".{proj}." in name:
+            return "row"
+    return None
+
+
+def load_sharded_checkpoint(model: nn.Module, checkpoint_path: str) -> None:
+    """Load `checkpoint_path` (safetensors) into `model`, slicing TP-sharded
+    tensors to this rank. Replicated tensors are loaded whole. Parameters/buffers
+    not present in the checkpoint (e.g. rotary inv_freq) are left as initialised.
+
+    The model is expected to already be materialised on the target device with
+    TP-local parameter shapes (i.e. built while the TP group is active).
+    """
+    from safetensors import safe_open
+
+    ws = get_tp_world_size()
+    rank = get_tp_rank()
+    state = model.state_dict()
+
+    with safe_open(checkpoint_path, framework="pt", device="cpu") as f:
+        ckpt_keys = set(f.keys())
+        for name, param in state.items():
+            if name not in ckpt_keys:
+                continue
+
+            kind = _shard_kind(name) if ws > 1 else None
+            if kind is None:
+                tensor = f.get_tensor(name)
+            else:
+                sl = f.get_slice(name)
+                shape = sl.get_shape()
+                if kind == "col":
+                    local = shape[0] // ws
+                    tensor = sl[rank * local:(rank + 1) * local]
+                else:  # row
+                    if len(shape) == 1:
+                        # 1-D row-parallel tensors don't occur here, but be safe.
+                        tensor = sl[:]
+                    else:
+                        local = shape[1] // ws
+                        tensor = sl[:, rank * local:(rank + 1) * local]
+
+            with torch.no_grad():
+                param.copy_(tensor.to(dtype=param.dtype, device=param.device))


### PR DESCRIPTION
Implements Megatron-style tensor parallelism for the latency-critical LLM
forward path, runnable SPMD under `torchrun` (e.g. 4×H100 + NVLink). The model
is custom Qwen2 MoT code, so HF/vLLM auto-TP isn't usable — sharding is done by hand.

## Changes
- **modeling/tp_utils.py** — process-group init, `ColumnParallelLinear` /
  `RowParallelLinear` (row does the all-reduce), per-rank sharded safetensors
  loader. All primitives degrade to plain `nn.Linear` when `WORLD_SIZE==1`, so
  the single-GPU path is unchanged.
- **modeling/qwen2/modeling_qwen2.py** — `Qwen2Attention`/`Qwen2MLP` use parallel
  linears with per-rank head counts; q/k/v + gate/up column-parallel, o + down
  row-parallel (2 all-reduces/layer).
- **modeling/bagel/qwen2_navit.py** — shard the `*_moe_gen` (generation expert)
  projections the same way; fix attention reshapes to the local inner dim.
- **infer_tp.py** — torchrun entrypoint; drives the existing `InterleaveInferencer`.
- **infer_tp_edit.py** — TP lockstep driver for an image-edit dataset.

GQA grouping is preserved per rank; layernorms, RoPE, q/k norms, embeddings,
lm_head, ViT and VAE stay replicated.

## Testing
Not yet run on GPU (no H100 access in dev). To validate: compare
`--nproc_per_node=1` vs `=4` output with the same seed/prompt (should be visually
identical), and check the `--benchmark` timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)